### PR TITLE
AfterEach should always be invoked if BeforeEach was successfully invoked

### DIFF
--- a/src/main/java/impl/com/github/paulcwarren/ginkgo4j/runner/SpecRunner.java
+++ b/src/main/java/impl/com/github/paulcwarren/ginkgo4j/runner/SpecRunner.java
@@ -21,15 +21,17 @@ public class SpecRunner implements Runner {
 		for (ExecutableBlock block : chain.getBeforeEachs()) {
 			block.invoke();
 		}
-	
-		for (ExecutableBlock block : chain.getJustBeforeEachs()) {
-			block.invoke();
-		}
-	
-		chain.getSpec().invoke();
 
-		for (ExecutableBlock block : chain.getAfterEachs()) {
-			block.invoke();
-    	}
+		try {
+			for (ExecutableBlock block : chain.getJustBeforeEachs()) {
+				block.invoke();
+			}
+
+			chain.getSpec().invoke();
+		} finally {
+			for (ExecutableBlock block : chain.getAfterEachs()) {
+				block.invoke();
+			}
+		}
 	}
 }

--- a/src/test/java/impl/com/github/paulcwarren/ginkgo4j/runner/SpecRunnerThreadTests.java
+++ b/src/test/java/impl/com/github/paulcwarren/ginkgo4j/runner/SpecRunnerThreadTests.java
@@ -77,6 +77,25 @@ public class SpecRunnerThreadTests {
 				
 			});
 
+			Context("when a JustBeforeEach throws an Exception", () -> {
+
+				BeforeEach(() ->{
+					setupOneBeforeOneAfterSpec();
+					justBefore = mock(ExecutableBlock.class);
+					chain.getJustBeforeEachs().add(justBefore);
+					doThrow(Exception.class).when(justBefore).invoke();
+				});
+
+				It("should call Before, JustBefore and After", () -> {
+					InOrder order = inOrder(/*notifier, */before, justBefore, after);
+					order.verify(before).invoke();
+					order.verify(justBefore).invoke();
+					order.verify(after).invoke();
+					verifyNoMoreInteractions(/*notifier, */before, justBefore, after);
+				});
+
+			});
+
 			Context("when an it throws an Exception", () -> {
 
 				BeforeEach(() ->{
@@ -84,13 +103,13 @@ public class SpecRunnerThreadTests {
 					doThrow(Exception.class).when(it).invoke();
 				});
 				
-				It("should call before each but not the spec or afters", () -> {
+				It("it should still call AfterEach after the spec", () -> {
 					InOrder order = inOrder(/*notifier, */before, it, after);
 					order.verify(before).invoke();
 					order.verify(it).invoke();
+					order.verify(after).invoke();
 					verifyNoMoreInteractions(/*notifier, */before, it, after);
 				});
-				
 			});
 
 


### PR DESCRIPTION
Can you also bump the maven release if you accept this patch?

Thanks
