### PR TITLE
fix: executablechain context list now represents the context levels found in the test being parsed

### DIFF
--- a/src/main/java/impl/com/github/paulcwarren/ginkgo4j/Context.java
+++ b/src/main/java/impl/com/github/paulcwarren/ginkgo4j/Context.java
@@ -2,13 +2,16 @@ package impl.com.github.paulcwarren.ginkgo4j;
 
 import com.github.paulcwarren.ginkgo4j.ExecutableBlock;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Context {
 	
 	private String id;
 	
-	private ExecutableBlock be;
-	private ExecutableBlock jbe;
-	private ExecutableBlock a;
+	private List<ExecutableBlock> be = new ArrayList<>();
+	private List<ExecutableBlock> jbe = new ArrayList<>();
+	private List<ExecutableBlock> ae = new ArrayList<>();
 	
 	public Context(String id) {
 		this.id = id;
@@ -18,28 +21,28 @@ public class Context {
 		return this.id;
 	}
 	
-	public void setBeforeEach(ExecutableBlock be) {
-		this.be = be;
+	public void addBeforeEach(ExecutableBlock be) {
+		this.be.add(be);
 	}
 
-	public ExecutableBlock getBeforeEach() {
+	public List<ExecutableBlock> getBeforeEach() {
 		return this.be;
 	}
 
 	public void setJustBeforeEach(ExecutableBlock jbe) {
-		this.jbe = jbe;
+		this.jbe.add(jbe);
 	}
 
-	public ExecutableBlock getJustBeforeEach() {
+	public List<ExecutableBlock> getJustBeforeEach() {
 		return this.jbe;
 	}
 
 	public void setAfterEach(ExecutableBlock a) {
-		this.a = a;
+		this.ae.add(a);
 	}
 
-	public ExecutableBlock getAfterEach() {
-		return this.a;
+	public List<ExecutableBlock> getAfterEach() {
+		return this.ae;
 	}
 }
 

--- a/src/main/java/impl/com/github/paulcwarren/ginkgo4j/chains/ExecutableChain.java
+++ b/src/main/java/impl/com/github/paulcwarren/ginkgo4j/chains/ExecutableChain.java
@@ -58,11 +58,20 @@ public class ExecutableChain {
 		for (Context c : context) {
 			try {
 				if (c.getBeforeEach() != null) {
-					c.getBeforeEach().invoke();
+					for (ExecutableBlock block : c.getBeforeEach()) {
+						if (block != null) {
+							block.invoke();
+						}
+					}
 				}
 			} catch (Throwable t) {
+				t.printStackTrace();
 				if (c.getAfterEach() != null) {
-					c.getAfterEach().invoke();
+					for (ExecutableBlock block : c.getAfterEach()) {
+						if (block != null) {
+							block.invoke();
+						}
+					}
 				}
 				throw t;
 			}
@@ -71,11 +80,19 @@ public class ExecutableChain {
 		for (Context c : context) {
 			try {
 				if (c.getJustBeforeEach() != null) {
-					c.getJustBeforeEach().invoke();
+					for (ExecutableBlock block : c.getJustBeforeEach()) {
+						if (block != null) {
+							block.invoke();
+						}
+					}
 				}
 			} catch (Throwable t) {
 				if (c.getAfterEach() != null) {
-					c.getAfterEach().invoke();
+					for (ExecutableBlock block : c.getAfterEach()) {
+						if (block != null) {
+							block.invoke();
+						}
+					}
 				}
 				throw t;
 			}
@@ -85,9 +102,10 @@ public class ExecutableChain {
 			this.getSpec().invoke();
 		} finally {
 			for (int i = context.size() - 1; i >= 0; i--) {
-				ExecutableBlock block = context.get(i).getAfterEach();
-				if (block != null) {
-					block.invoke();
+				for (ExecutableBlock block : context.get(i).getAfterEach()) {
+					if (block != null) {
+						block.invoke();
+					}
 				}
 			}
 		}

--- a/src/test/java/com/github/paulcwarren/ginkgo4j/ExampleTests.java
+++ b/src/test/java/com/github/paulcwarren/ginkgo4j/ExampleTests.java
@@ -1,11 +1,7 @@
 package com.github.paulcwarren.ginkgo4j;
 
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.AfterEach;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.BeforeEach;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.Context;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.Describe;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.It;
-import static org.hamcrest.CoreMatchers.is;
+import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Ignore;
@@ -13,13 +9,15 @@ import org.junit.runner.RunWith;
 
 import junit.framework.Assert;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 @Ignore
 @SuppressWarnings("deprecation")
 @RunWith(Ginkgo4jRunner.class)
 //@Ginkgo4jConfiguration(threads=1)
 public class ExampleTests {
 	
-	private  String something;
+	private String something = "";
 
 	private Example example;
 	{
@@ -41,50 +39,50 @@ public class ExampleTests {
         });
 
         Describe("A describe", () -> {
-			
+
 			BeforeEach(() -> {
 				example = new Example();
-				
+
 				example.setStatus("describe");
 			});
 
 			AfterEach(() -> {
 				Assert.assertNull(example);
 			});
-			
+
 			It("should pass", () -> {
 				Thread.sleep(1000);
 				Assert.assertSame("describe", example.getStatus());
 				example = null;
 			});
-			
+
 			Context("a context", () -> {
 
 				BeforeEach(() -> {
 					example.setStatus("context");
 				});
-				
+
 				AfterEach(() -> {
 					example = null;
 				});
-				
+
 				It("should also pass", () -> {
 					Thread.sleep(1000);
 					Assert.assertSame("context", example.getStatus());
 				});
 
 			});
-			
+
 			Context("a second context", () -> {
 
 				BeforeEach(() -> {
 					example.setStatus("2nd context");
 				});
-				
+
 				AfterEach(() -> {
 					example = null;
 				});
-				
+
 				It("should fail", () -> {
 					Thread.sleep(1000);
 					Assert.assertSame("not this", example.getStatus());
@@ -92,7 +90,7 @@ public class ExampleTests {
 
 			});
 		});
-		
+
 		Describe("A 2nd describe", () -> {
 
 			BeforeEach(() -> {
@@ -109,7 +107,7 @@ public class ExampleTests {
 				throw new Exception("this test threw an unexpected exception");
 			});
 		});
-		
+
 		Context("parent context", () -> {
 
 			BeforeEach(() -> {
@@ -118,7 +116,9 @@ public class ExampleTests {
 
 			Describe("child context", () -> {
 				It("it", () -> {
-					Assert.assertTrue(true);
+					It("it", () -> {
+						Assert.assertTrue(true);
+					});
 				});
 			});
 		});

--- a/src/test/java/impl/com/github/paulcwarren/ginkgo4j/builder/ExecutableChainBuilderITests.java
+++ b/src/test/java/impl/com/github/paulcwarren/ginkgo4j/builder/ExecutableChainBuilderITests.java
@@ -1,0 +1,106 @@
+package impl.com.github.paulcwarren.ginkgo4j.builder;
+
+import com.github.paulcwarren.ginkgo4j.Ginkgo4jConfiguration;
+import com.github.paulcwarren.ginkgo4j.Ginkgo4jRunner;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(Ginkgo4jRunner.class)
+@Ginkgo4jConfiguration(threads = 1)
+public class ExecutableChainBuilderITests {
+
+	{
+		Describe("single context with multiple, unordered be's, jbe's and ae's", ()->{
+			AtomicReference<String> capture = new AtomicReference<>("");
+			AtomicReference<String> aeCapture = new AtomicReference<>("");
+			AfterEach(() -> {
+				assertThat(aeCapture.get(), is(""));
+				aeCapture.set("1");
+			});
+			AfterEach(() -> {
+				assertThat(aeCapture.get(), is("1"));
+			});
+			It("calls the be's, jbe's and ae's in the right order", () -> {
+				assertThat(capture.get(), is("4th"));
+			});
+			JustBeforeEach(() -> {
+				assertThat(capture.get(), is("2nd"));
+				capture.set("3rd");
+			});
+			JustBeforeEach(() -> {
+				assertThat(capture.get(), is("3rd"));
+				capture.set("4th");
+			});
+			BeforeEach(() -> {
+				assertThat(capture.get(), is(""));
+				capture.set("1st");
+			});
+			BeforeEach(() -> {
+				assertThat(capture.get(), is("1st"));
+				capture.set("2nd");
+			});
+		});
+
+		Describe("multiple context with multiple, unordered be's, jbe's and ae's", ()->{
+			AtomicReference<String> capture = new AtomicReference<>("");
+			AtomicReference<String> aeCapture = new AtomicReference<>("");
+			AfterEach(() -> {
+				assertThat(aeCapture.get(), is("2"));
+				aeCapture.set("3");
+			});
+			AfterEach(() -> {
+				assertThat(aeCapture.get(), is("3"));
+			});
+			Context("second context", ()->{
+				AfterEach(() -> {
+					assertThat(aeCapture.get(), is(""));
+					aeCapture.set("1");
+				});
+				AfterEach(() -> {
+					assertThat(aeCapture.get(), is("1"));
+					aeCapture.set("2");
+				});
+				It("then sets 2nd capture", () -> {
+					assertThat(capture.get(), is("8th"));
+				});
+				JustBeforeEach(() -> {
+					assertThat(capture.get(), is("6th"));
+					capture.set("7th");
+				});
+				JustBeforeEach(() -> {
+					assertThat(capture.get(), is("7th"));
+					capture.set("8th");
+				});
+				BeforeEach(() -> {
+					assertThat(capture.get(), is("2nd"));
+					capture.set("3rd");
+				});
+				BeforeEach(() -> {
+					assertThat(capture.get(), is("3rd"));
+					capture.set("4th");
+				});
+			});
+			BeforeEach(() -> {
+				assertThat(capture.get(), is(""));
+				capture.set("1st");
+			});
+			BeforeEach(() -> {
+				assertThat(capture.get(), is("1st"));
+				capture.set("2nd");
+			});
+			JustBeforeEach(() -> {
+				assertThat(capture.get(), is("4th"));
+				capture.set("5th");
+			});
+			JustBeforeEach(() -> {
+				assertThat(capture.get(), is("5th"));
+				capture.set("6th");
+			});
+		});
+	}
+}

--- a/src/test/java/impl/com/github/paulcwarren/ginkgo4j/builder/ExecutableChainBuilderTests.java
+++ b/src/test/java/impl/com/github/paulcwarren/ginkgo4j/builder/ExecutableChainBuilderTests.java
@@ -1,11 +1,6 @@
 package impl.com.github.paulcwarren.ginkgo4j.builder;
 
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.AfterEach;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.BeforeEach;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.Context;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.Describe;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.It;
-import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.JustBeforeEach;
+import static com.github.paulcwarren.ginkgo4j.Ginkgo4jDSL.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;

--- a/src/test/java/impl/com/github/paulcwarren/ginkgo4j/runner/SpecRunnerTests.java
+++ b/src/test/java/impl/com/github/paulcwarren/ginkgo4j/runner/SpecRunnerTests.java
@@ -262,7 +262,7 @@ public class SpecRunnerTests {
 					chain.getContext().get(0).setJustBeforeEach(justBefore);
 
 					before = mock(ExecutableBlock.class);
-					chain.getContext().get(1).setBeforeEach(before);
+					chain.getContext().get(1).addBeforeEach(before);
 
 					it = mock(ExecutableBlock.class);
 					chain.setSpec(it);
@@ -285,7 +285,7 @@ public class SpecRunnerTests {
 		chain.getContext().add(new Context(""));
 		
 		before = mock(ExecutableBlock.class);
-		chain.getContext().get(0).setBeforeEach(before);
+		chain.getContext().get(0).addBeforeEach(before);
 
 		it = mock(ExecutableBlock.class);
 		chain.setSpec(it);


### PR DESCRIPTION
- `ExecutionChain` parsing improved.  Now uses the context list to represent the context levels found in a test.   
- `ExecutionChain` can now capture multiple be's, jbe's and ae's regardless of where they are specified in the `Context`
- `ExecutionChain.execute` refactor to handle higher fidelity state captured on `ExecutionChain` 

- Fixes #8